### PR TITLE
format of the attributes

### DIFF
--- a/VE_bus.csv
+++ b/VE_bus.csv
@@ -1,1 +1,14 @@
-Attribute,Value,Property,URI,DescriptionLayer,BUSMADRID,mobilitymadrid:layers,http://mobilitylab.emtmadrid.es/def/layers#busmadrid,kind of layer into RB or Mobility systems. Layer ontology describes data domain Reactive Box and other elements of this entityidbus,[id of bus],schemas:Number,https://schemas.org/Number,Unique identifier of bus into EMT CompanyCorporation,EMT,Mobilitymadrid:corporation,https://schemas.org/Corporation,organization to which it belongsDateIni,[date ini],Dcterms:date,xsd:dateTime,Begin date of current informationDateEnd,[date end],Dcterms:valid,xsd:dateTime,End date of current informationDepo,[id depo],mobilitymadrid:depo,http://mobilitylab.emtmadrid.es/def/transport#Depo,Deposit which it belongsBrand,[name of brand],mobilitymadrid:brand,http://mobilitylab.emtmadrid.es/def/transport#Brand,Brand of busModel,[name of model],mobilitymadrid:model,http://mobilitylab.emtmadrid.es/def/transport#Model,Model which belongs into BrandVersion,[num],schemas:Number,https://schema.org/Number,Number of version into a specific model Plate,[id plate],schemas:Text,https://schemas.org/Text,Plate id of busCapacity,[num],schemas:Number,https://schemas.org/Number,Max capacity  of passengersFuelType,[type of fuel],Mobilitymadrid:fuelType,http://mobilitylab.emtmadrid.es/def/transport#fueltype,Type of fuel (ej  gas  electricity  etc)AccesibilityType,[type of accesibility],Mobilitymadrid:accessibilitytype,http://mobilitylab.emtmadrid.es/def/transport#accesibilitytype,Type of accesibility
+Attribute,Value,Property,URI,Description
+layer,BUSMADRID,mobilitymadrid:layers,http://mobilitylab.emtmadrid.es/def/layers#busmadrid,kind of layer into RB or Mobility systems. Layer ontology describes data domain Reactive Box and other elements of this entity
+idBus,[id of bus],schemas:Number,https://schemas.org/Number,Unique identifier of bus into EMT Company
+corporation,EMT,Mobilitymadrid:corporation,https://schemas.org/Corporation,organization to which it belongs
+dateIni,[date ini],Dcterms:date,xsd:dateTime,Begin date of current information
+dateEnd,[date end],Dcterms:valid,xsd:dateTime,End date of current information
+depo,[id depo],mobilitymadrid:depo,http://mobilitylab.emtmadrid.es/def/transport#Depo,Deposit which it belongs
+brand,[name of brand],mobilitymadrid:brand,http://mobilitylab.emtmadrid.es/def/transport#Brand,Brand of bus
+model,[name of model],mobilitymadrid:model,http://mobilitylab.emtmadrid.es/def/transport#Model,Model which belongs into Brand
+version,[num],schemas:Number,https://schema.org/Number,Number of version into a specific model 
+plate,[id plate],schemas:Text,https://schemas.org/Text,Plate id of bus
+capacity,[num],schemas:Number,https://schemas.org/Number,Max capacity  of passengers
+fuelType,[type of fuel],Mobilitymadrid:fuelType,http://mobilitylab.emtmadrid.es/def/transport#fueltype,Type of fuel (ej  gas  electricity  etc)
+accesibilityType,[type of accesibility],Mobilitymadrid:accessibilitytype,http://mobilitylab.emtmadrid.es/def/transport#accesibilitytype,Type of accesibility


### PR DESCRIPTION
I have checked that there is not an unique format for the attributes so I propose the following format:
The attribute starts with capital letter and if there it is referring to more than one word, the next word should start with capital letter. Examples: idBus instead of idbus, or dataInit instead of DateInit.
